### PR TITLE
various fixes for onlyswaps-verifier runbooks

### DIFF
--- a/runbooks/generate-onlyswaps-config.md
+++ b/runbooks/generate-onlyswaps-config.md
@@ -20,8 +20,8 @@
 onlyswaps-verifier generate-config \
   --private /path/to/longterm/private/key \       
   --group /path/to/group.toml \
-  --public-share /path/to/public/keyshare \
-  --private-share /path/to/private/keyshare \
+  --adkg-public /path/to/public/keyshare \
+  --adkg-private /path/to/private/keyshare \
   --multiaddr "/ip4/0.0.0.0/tcp/1234" \
   --member-id $SOME_MEMBER_ID
 ```

--- a/runbooks/generate-onlyswaps-config.md
+++ b/runbooks/generate-onlyswaps-config.md
@@ -20,8 +20,8 @@
 onlyswaps-verifier generate-config \
   --private /path/to/longterm/private/key \       
   --group /path/to/group.toml \
-  --adkg-public /path/to/public/keyshare \
-  --adkg-private /path/to/private/keyshare \
+  --public-share /path/to/public/keyshare \
+  --private-share /path/to/private/keyshare \
   --multiaddr "/ip4/0.0.0.0/tcp/1234" \
   --member-id $SOME_MEMBER_ID
 ```

--- a/runbooks/run-onlyswaps-verifier.md
+++ b/runbooks/run-onlyswaps-verifier.md
@@ -17,7 +17,7 @@
    Choose whichever works best, and follow the steps below.
 
 ## systemd
-**1. Move onlyswaps-verifier binary to /opt**  
+**1. (Optional) Move onlyswaps-verifier binary to /opt**  
 Run the following commands to move the onlyswaps-verifier binary to `/opt/onlyswaps/onlyswaps-verifier`.
 ```bash
 # move onlyswaps-verifier binary to /opt/onlyswaps/onlyswaps-verifier
@@ -62,6 +62,7 @@ Type=simple
 # TODO: Remove/update it if you didn't create a user
 User=onlyswaps
 Group=onlyswaps
+# TODO: Update path if not using /opt
 ExecStart=/opt/onlyswaps/onlyswaps-verifier start --config /etc/onlyswaps/verifier.toml
 Restart=always
 RestartSec=10

--- a/runbooks/run-onlyswaps-verifier.md
+++ b/runbooks/run-onlyswaps-verifier.md
@@ -112,7 +112,7 @@ With docker compose, you may either run the service as root, or with another use
          - "7777:7777"
        volumes:
          - path/to/my/config.toml:/etc/onlyswaps/verifier.toml:ro
-       command: ["start", "--config", "/etc/onlyswaps/verifier.toml"]
+       command: ["--config", "/etc/onlyswaps/verifier.toml"]
    ```
 2. Update the user id if different than the current user. If executing as root, use `user: "0:0"` (or comment the line).
 3. Update the libp2p port in the docker-compose file if different. If you use, say port `8888`, you should replace `7777:7777` with `8888:8888` instead.


### PR DESCRIPTION
- Make moving binary to `/opt` optional, and add todo to update path in unit file if required
- Remove start from onlyswaps-verifier docker command